### PR TITLE
Refresh token update implementing

### DIFF
--- a/src/main/java/ru/finess/finess/identity/infrastructure/JwtValidator.java
+++ b/src/main/java/ru/finess/finess/identity/infrastructure/JwtValidator.java
@@ -17,16 +17,22 @@ import ru.finess.finess.identity.domain.UserId;
 @Component
 public class JwtValidator {
 
-  private final JwtParser parser;
+  private final JwtParser accessTokenParser;
+  private final JwtParser refreshTokenParser;
 
-  public JwtValidator(@Value("${session.jwt.access.key}") String secretKey) {
-    this.parser =
-        Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes())).build();
+  public JwtValidator(
+      @Value("${session.jwt.access.key}") String accessKey,
+      @Value("${session.jwt.refresh.key}") String refreshKey) {
+
+    this.accessTokenParser =
+        Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(accessKey.getBytes())).build();
+    this.refreshTokenParser =
+        Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(refreshKey.getBytes())).build();
   }
 
   public Optional<Session> validateSession(@NonNull String rawAccessToken) {
     try {
-      Jws<Claims> claimsJws = parser.parseClaimsJws(rawAccessToken);
+      Jws<Claims> claimsJws = accessTokenParser.parseClaimsJws(rawAccessToken);
       Claims body = claimsJws.getBody();
       OffsetDateTime expirationDate = DateUtils.toOffsetDateTime(body.getExpiration());
       UserId userId = UserId.fromString(body.getSubject());
@@ -35,6 +41,19 @@ public class JwtValidator {
       return Optional.of(Session.builder().user(userId).accessToken(accessToken).build());
     } catch (JwtException | IllegalArgumentException e) {
       log.error("Invalid JWT accessToken: {}", e.getMessage());
+      return Optional.empty();
+    }
+  }
+
+  public Optional<UserId> getSubject(@NonNull String rawRefreshToken) {
+    try {
+      Jws<Claims> claimsJws = refreshTokenParser.parseClaimsJws(rawRefreshToken);
+      Claims body = claimsJws.getBody();
+      UserId userId = UserId.fromString(body.getSubject());
+
+      return Optional.of(userId);
+    } catch (JwtException | IllegalArgumentException e) {
+      log.error("Invalid JWT refreshToken: {}", e.getMessage());
       return Optional.empty();
     }
   }

--- a/src/main/java/ru/finess/finess/identity/presentation/SessionManagementRestApi.java
+++ b/src/main/java/ru/finess/finess/identity/presentation/SessionManagementRestApi.java
@@ -15,12 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.finess.finess.identity.application.SessionCreationUseCase;
 import ru.finess.finess.identity.application.UserAuthenticationUseCase;
 import ru.finess.finess.identity.application.UserRegistrationUseCase;
-import ru.finess.finess.identity.domain.Session;
-import ru.finess.finess.identity.domain.User;
-import ru.finess.finess.identity.domain.UserId;
-import ru.finess.finess.identity.domain.UserPassword;
+import ru.finess.finess.identity.domain.*;
+import ru.finess.finess.identity.infrastructure.JwtValidator;
 import ru.finess.finess.identity.presentation.api.SessionManagementApi;
 import ru.finess.finess.identity.presentation.dto.SessionDto;
+import ru.finess.finess.identity.presentation.dto.TokenRefreshParametersDto;
 import ru.finess.finess.identity.presentation.dto.UserRegistrationParametersDto;
 import ru.finess.finess.identity.presentation.dto.UserSigninParametersDto;
 
@@ -34,6 +33,7 @@ public class SessionManagementRestApi implements SessionManagementApi {
   private final UserRegistrationUseCase registrationUseCase;
   private final SessionCreationUseCase sessionCreationUseCase;
   private final UserAuthenticationUseCase userAuthenticationUseCase;
+  private final JwtValidator jwtValidator;
 
   @Override
   public ResponseEntity<SessionDto> registerUser(
@@ -41,6 +41,7 @@ public class SessionManagementRestApi implements SessionManagementApi {
     UserPassword password = new UserPassword(userRegistrationParametersDto.getPassword());
 
     return registerUser(password)
+        .map(User::id)
         .flatMap(this::createSession)
         .map(this::toDto)
         .recoverError(error -> ResponseEntity.status(error).build());
@@ -52,6 +53,18 @@ public class SessionManagementRestApi implements SessionManagementApi {
     UserPassword password = new UserPassword(userSigninParametersDto.getPassword());
 
     return signinUser(user, password)
+        .map(User::id)
+        .flatMap(this::createSession)
+        .map(this::toDto)
+        .recoverError(error -> ResponseEntity.status(error).build());
+  }
+
+  @Override
+  public ResponseEntity<SessionDto> refreshToken(
+      TokenRefreshParametersDto tokenRefreshParametersDto) {
+    String rawRefreshToken = tokenRefreshParametersDto.getRefreshToken();
+
+    return Result.fromOptional(jwtValidator.getSubject(rawRefreshToken), HttpStatus.UNAUTHORIZED)
         .flatMap(this::createSession)
         .map(this::toDto)
         .recoverError(error -> ResponseEntity.status(error).build());
@@ -66,9 +79,9 @@ public class SessionManagementRestApi implements SessionManagementApi {
         .mapError(ignored -> HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
-  private Result<Session, HttpStatus> createSession(User user) {
+  private Result<Session, HttpStatus> createSession(UserId userId) {
     SessionCreationUseCase.Parameters parameters =
-        new SessionCreationUseCase.Parameters(user.id(), OffsetDateTime.now());
+        new SessionCreationUseCase.Parameters(userId, OffsetDateTime.now());
     return sessionCreationUseCase
         .execute(parameters)
         .mapError(ignored -> HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/test/java/ru/finess/finess/identity/presentation/SessionManagementRestApiIT.java
+++ b/src/test/java/ru/finess/finess/identity/presentation/SessionManagementRestApiIT.java
@@ -1,9 +1,11 @@
 package ru.finess.finess.identity.presentation;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +14,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import ru.finess.finess.IntegrationTest;
 import ru.finess.finess.common.UserMother;
+import ru.finess.finess.identity.application.SessionCreationUseCase;
+import ru.finess.finess.identity.domain.Session;
 import ru.finess.finess.identity.domain.User;
 import ru.finess.finess.identity.domain.UserId;
 import ru.finess.finess.identity.domain.UserPassword;
@@ -22,6 +26,8 @@ class SessionManagementRestApiIT {
   @Autowired MockMvc mockMvc;
 
   @Autowired UserMother userMother;
+
+  @Autowired private SessionCreationUseCase sessionCreationUseCase;
 
   @DisplayName("Check user authenticated")
   @Test
@@ -123,6 +129,60 @@ class SessionManagementRestApiIT {
             post("/api/identity/v1/tokens")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @DisplayName("Check token refreshed")
+  @Test
+  void getRefreshToken() throws Exception {
+    // Arrange
+    User user = userMother.create();
+    Session session =
+        sessionCreationUseCase
+            .execute(new SessionCreationUseCase.Parameters(user.id(), OffsetDateTime.now()))
+            .orOnErrorThrow(
+                ignored -> new RuntimeException("Failed to create session" + user.id()));
+
+    String requestBody =
+        """
+            {
+              "refreshToken": "%s"
+            }
+            """
+            .formatted(session.refreshToken().value());
+
+    // Act & Assert
+    ResultActions resultActions =
+        mockMvc
+            .perform(
+                post("/api/identity/v1/tokens:refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andDo(print())
+            .andExpect(status().isOk());
+
+    expectTokensExists(resultActions);
+  }
+
+  @DisplayName("Check invalid token")
+  @Test
+  void invalidRefreshToken() throws Exception {
+    // Arrange
+    String requestBody =
+        """
+            {
+              "refreshToken": "%s"
+            }
+            """
+            .formatted("12345dadsjkds");
+
+    // Act & Assert
+    mockMvc
+        .perform(
+            post("/api/identity/v1/tokens:refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andDo(print())
         .andExpect(status().isUnauthorized());
   }
 


### PR DESCRIPTION
Implemented of refreshToken method (/v1/tokens:refresh endpoint), changed parameter type in createSession method (from User to UserId), changed createSession method calls in others methods, added parser for refresh tokens in JwtValidator, implemented refresh token validation (getSubject method)

Jira ID: FIN-34
Testing done: Manually